### PR TITLE
DNS updates rework

### DIFF
--- a/records/records.go
+++ b/records/records.go
@@ -29,44 +29,43 @@ func Update(apikey string, secretkey string) {
 
 	domains := strings.Split(domainsString, ",")
 
-	if value, present := env.ReadOptionalEnv(IPv4EnvKey); value == "true" || present == false {
+	IPv4Value, IPv6ValuePresent := env.ReadOptionalEnv(IPv4EnvKey)
+	IPv6Value, _ := env.ReadOptionalEnv(IPv6EnvKey)
+
+	var currentIPv4 string
+	var IPv4Err error
+
+	if IPv4Value == "true" || IPv6ValuePresent == false {
 		// Either user set IPV4=true or he didn't set it at all (standard value)
-		currentIPv4, err := wanip.GetFromFritzBox("ipv4")
-		if err != nil {
+		currentIPv4, IPv4Err = wanip.GetFromFritzBox("ipv4")
+		if IPv4Err != nil {
 			logger.Warnf("Retrieving current WAN IPv4 via FRITZ!Box failed.")
-		} else {
-			updateFinalIPRecords(domains, apikey, secretkey, currentIPv4, "A")
 		}
 	}
 
-	if IPv6Value, _ := env.ReadOptionalEnv(IPv6EnvKey); IPv6Value == IPv6FritzBoxIPValue {
+	var currentFritzboxIPv6, currentHostIPv6, currentIPv6Prefix string
+	var IPv6Err error
+
+	if IPv6Value == IPv6FritzBoxIPValue {
 		// The user set IPV6=fritzbox-ip explicitly
-		currentFritzboxIPv6, err := wanip.GetFromFritzBox("ipv6")
-		if err != nil {
+		currentFritzboxIPv6, IPv6Err = wanip.GetFromFritzBox("ipv6")
+		if IPv6Err != nil {
 			logger.Warnf("Retrieving current WAN IPv6 of FRITZ!Box failed.")
-		} else {
-			updateFinalIPRecords(domains, apikey, secretkey, currentFritzboxIPv6, "AAAA")
 		}
 	} else if IPv6Value == IPv6HostIPValue {
 		// The user set IPV6=host-ip explicitly
-		currentHostIPv6, err := wanip.GetGlobalUnicastIPv6()
-		if err != nil {
+		currentHostIPv6, IPv6Err = wanip.GetGlobalUnicastIPv6()
+		if IPv6Err != nil {
 			logger.Warnf("Retrieving current host IPv6 failed. Is the host running on a (Docker) network with IPv6 support?")
-		} else {
-			updateFinalIPRecords(domains, apikey, secretkey, currentHostIPv6, "AAAA")
 		}
 	} else if IPv6Value == IPv6PrefixOnlyValue {
 		// The user set IPV6=prefix-only explicitly
-		currentIPv6Prefix, err := wanip.GetIPv6PrefixFromFritzBox()
-		if err != nil {
+		currentIPv6Prefix, IPv6Err = wanip.GetIPv6PrefixFromFritzBox()
+		if IPv6Err != nil {
 			logger.Warnf("Retrieving current IPv6 prefix via FRITZ!Box failed.")
-		} else {
-			updateIPv6Prefix(domains, apikey, secretkey, currentIPv6Prefix)
 		}
 	}
-}
 
-func updateFinalIPRecords(domains []string, apikey string, secretkey string, currentIP string, recordType string) {
 	for _, fqdn := range domains {
 		if !isFQDNValid(fqdn) {
 			logger.Warnf("%s is not a valid domain.", fqdn)
@@ -75,73 +74,76 @@ func updateFinalIPRecords(domains []string, apikey string, secretkey string, cur
 
 		subdomain, rootDomain := getSubAndRootDomain(fqdn)
 
-		retrievedRecords, err := retrieveRecords(subdomain, rootDomain, recordType, apikey, secretkey)
-		if err != nil {
-			logger.Warnf("Skipping %s-Record update of %s because retrieval of active records failed.", recordType, fqdn)
-			return
+		// TODO test ipv4/6err
+
+		if (IPv4Value == "true" || IPv6ValuePresent == false) && IPv4Err != nil {
+			assert.Assert(currentIPv4 != "", "currentIPv4 should be set here because it's checked in the beginning of this function")
+			tryUpdateRecordWithConstIP(currentIPv4, "A", fqdn, subdomain, rootDomain, apikey, secretkey)
 		}
 
-		switch len(retrievedRecords) {
-		case 0:
-			createRecord(subdomain, rootDomain, recordType, currentIP, apikey, secretkey)
-		case 1:
-			oldRecord := retrievedRecords[0]
-			if oldRecord.IP == currentIP {
-				log.Printf("%s-Record of %s is up to date.", recordType, fqdn)
-				continue
-			}
-
-			editRecord(subdomain, rootDomain, recordType, currentIP, apikey, secretkey, oldRecord.ID, oldRecord.IP)
-		default:
-			logger.Warnf("Multiple active %s-Records found for %s. Please clean up the DNS records in the Porkbun WebGUI or set the environment variable %s=%s to automatically unify them.",
-				recordType, fqdn, mulRecordsEnvKey, mulRecordsUnifyValue)
+		if IPv6Value == IPv6FritzBoxIPValue && IPv6Err != nil {
+			assert.Assert(currentFritzboxIPv6 != "", "currentFritzboxIPv6 should be set here because it's checked in the beginning of this function")
+			tryUpdateRecordWithConstIP(currentFritzboxIPv6, "AAAA", fqdn, subdomain, rootDomain, apikey, secretkey)
+		} else if IPv6Value == IPv6HostIPValue && IPv6Err != nil {
+			assert.Assert(currentHostIPv6 != "", "currentHostIPv6 should be set here because it's checked in the beginning of this function")
+			tryUpdateRecordWithConstIP(currentHostIPv6, "AAAA", fqdn, subdomain, rootDomain, apikey, secretkey)
+		} else if IPv6Value == IPv6PrefixOnlyValue && IPv6Err != nil {
+			assert.Assert(currentIPv6Prefix != "", "currentIPv6Prefix should be set here because it's checked in the beginning of this function")
+			tryUpdateRecordWithIPv6Prefix(currentIPv6Prefix, fqdn, subdomain, rootDomain, apikey, secretkey)
 		}
 	}
 }
 
-func handleRetrievedRecordsConstIP() {
+func tryUpdateRecordWithConstIP(currentIP string, recordType string, fqdn string, subdomain string, rootDomain string, apikey string, secretkey string) {
+	retrievedRecords, err := retrieveRecords(subdomain, rootDomain, recordType, apikey, secretkey)
+	if err != nil {
+		logger.Warnf("Skipping %s-Record update of %s because retrieval of active records failed. %s", recordType, fqdn, err)
+		return
+	}
 
+	switch len(retrievedRecords) {
+	case 0:
+		createRecord(subdomain, rootDomain, recordType, currentIP, apikey, secretkey)
+	case 1:
+		oldRecord := retrievedRecords[0]
+		if oldRecord.IP == currentIP {
+			log.Printf("%s-Record of %s is up to date.", recordType, fqdn)
+			return
+		}
+
+		editRecord(subdomain, rootDomain, recordType, currentIP, apikey, secretkey, oldRecord.ID, oldRecord.IP)
+	default:
+		logger.Warnf("Multiple active %s-Records found for %s. Please clean up the DNS records in the Porkbun WebGUI or set the environment variable %s=%s to automatically unify them.",
+			recordType, fqdn, mulRecordsEnvKey, mulRecordsUnifyValue)
+	}
 }
 
-func handleRetrievedRecordsIPv6Prefix() {
-
-}
-
-func updateIPv6Prefix(domains []string, apikey string, secretkey string, currentIPv6Prefix string) {
+func tryUpdateRecordWithIPv6Prefix(currentIPv6Prefix string, fqdn string, subdomain string, rootDomain string, apikey string, secretkey string) {
 	recordType := "AAAA"
 
-	for _, fqdn := range domains {
-		if !isFQDNValid(fqdn) {
-			logger.Warnf("%s is not a valid domain.", fqdn)
+	retrievedRecords, err := retrieveRecords(subdomain, rootDomain, recordType, apikey, secretkey)
+	if err != nil {
+		logger.Warnf("Skipping %s-Record update of %s because retrieval of active records failed.", recordType, fqdn)
+		return
+	}
+
+	switch len(retrievedRecords) {
+	case 0:
+		logger.Warnf("No %s-Record found for %s. Can only edit existing %[1]s-Records with %[3]s=%s.", recordType, fqdn, IPv6EnvKey, IPv6PrefixOnlyValue)
+	case 1:
+		oldRecord := retrievedRecords[0]
+
+		IPv6Addr := combineIPv6PrefixAndInterfaceID(currentIPv6Prefix, oldRecord.IP)
+
+		if oldRecord.IP == IPv6Addr {
+			log.Printf("%s-Record of %s is up to date.", recordType, fqdn)
 			return
 		}
 
-		subdomain, rootDomain := getSubAndRootDomain(fqdn)
-
-		retrievedRecords, err := retrieveRecords(subdomain, rootDomain, recordType, apikey, secretkey)
-		if err != nil {
-			logger.Warnf("Skipping %s-Record update of %s because retrieval of active records failed.", recordType, fqdn)
-			return
-		}
-
-		switch len(retrievedRecords) {
-		case 0:
-			logger.Warnf("No %s-Record found for %s. Can only edit existing %[1]s-Records with %[3]s=%s.", recordType, fqdn, IPv6EnvKey, IPv6PrefixOnlyValue)
-		case 1:
-			oldRecord := retrievedRecords[0]
-
-			IPv6Addr := combineIPv6PrefixAndInterfaceID(currentIPv6Prefix, oldRecord.IP)
-
-			if oldRecord.IP == IPv6Addr {
-				log.Printf("%s-Record of %s is up to date.", recordType, fqdn)
-				continue
-			}
-
-			editRecord(subdomain, rootDomain, recordType, IPv6Addr, apikey, secretkey, oldRecord.ID, oldRecord.IP)
-		default:
-			logger.Warnf("Multiple active %s-Records found for %s. Can only edit existing %[1]s-Records with %[3]s=%s.",
-				recordType, fqdn, IPv6EnvKey, IPv6PrefixOnlyValue)
-		}
+		editRecord(subdomain, rootDomain, recordType, IPv6Addr, apikey, secretkey, oldRecord.ID, oldRecord.IP)
+	default:
+		logger.Warnf("Multiple active %s-Records found for %s. Can only edit existing %[1]s-Records with %[3]s=%s.",
+			recordType, fqdn, IPv6EnvKey, IPv6PrefixOnlyValue)
 	}
 }
 


### PR DESCRIPTION
Updates are now as follow: A-Record FQDN1, AAAA-Record FQDN1, A-Record FQDN2, AAAA-Record FQDN2, ...

Previously updated all A-Records first and AAAA-Records last.

This restores original update order.